### PR TITLE
runs_on has an explicit tag for the build agent

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,9 @@ on:
 
 jobs:
   build-win64:
-    name: Build for Win64
+    name: Build for Win64 [runs-on: build_agent]
 
-    runs-on: self-hosted
+    runs-on: build_agent
 
     timeout-minutes: 120
 


### PR DESCRIPTION
Tag is also repeated in the workflow run name. This will be used by the build agent monitoring utility, to understand which agents need to be running when.