### PR TITLE
Quote job name due to square brackets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-win64:
-    name: Build for Win64 [runs-on: build_agent]
+    name: "Build for Win64 [runs-on: build_agent]"
 
     runs-on: build_agent
 


### PR DESCRIPTION
The job name included square brackets; these need to be quoted.